### PR TITLE
Simplify Seurat Dockerfile

### DIFF
--- a/crescent/Dockerfile
+++ b/crescent/Dockerfile
@@ -1,4 +1,4 @@
-FROM bioconductor/release_base2:latest
+FROM r-base:latest
 
 RUN apt-get update && \
     apt-get install -y libcurl4-openssl-dev libhdf5-dev libssl-dev libxml2-dev \

--- a/crescent/Dockerfile
+++ b/crescent/Dockerfile
@@ -1,92 +1,12 @@
-FROM ubuntu:19.04
-
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && \
-    apt-get install -y \
-            wget \
-            curl \ 
-            gcc \
-            pdftk-java \
-            g++ \
-            make \
-            libssl-dev \ 
-            libcurl4-openssl-dev \
-            libhdf5-dev \
-            git \
-            vim \
-            r-base \ 
-            openjdk-8-jre
-
-# Seurat
-RUN Rscript -e "install.packages('Seurat')"
-RUN Rscript -e "install.packages('fmsb')"
-RUN Rscript -e "install.packages('optparse')"
-RUN Rscript -e "install.packages('staplr')"
-
-
-# cellranger
-#RUN wget -O cellranger-3.1.0.tar.gz "http://cf.10xgenomics.com/releases/cell-exp/cellranger-3.1.0.tar.gz?Expires=1573889510&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cDovL2NmLjEweGdlbm9taWNzLmNvbS9yZWxlYXNlcy9jZWxsLWV4cC9jZWxscmFuZ2VyLTMuMS4wLnRhci5neiIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTU3Mzg4OTUxMH19fV19&Signature=QLEcdq7gQhKtp~HHPr8UL6PVG3sWotJSu8Wy08f0DW0mgp5uk8ea6rJd1d3ENzt0O0BySZ0LRAPUEyppPTP1JOLPibxzlRkDk9uufJDNDvzQrCHIXr3Mp8uXD6VMd3PLMHfCref28jOhWGWtRN92gtoF2ERAiV9nEK45BK5p1lo8rmvus96Njzmp8RQOWJnEILmO4pD~t-nILphKCsTOn6f8-YwUBk0aHbcb6f4CQ0zgYKeJKTRASkwhHKt1ooxVGIohBn~P8b9ShhrPu6M3ecGNXK1E86o0wAnFNFk4tOKtVeo79MH~BXO95f1yzVkxNrt49CeC3wzG2NMicrHzkg__&Key-Pair-Id=APKAI7S6A5RYOXBWRPDA"
-
-#RUN apt-get install -y bsdtar \
-#    && cp $(which tar) $(which tar)~ \
-#    && ln -sf $(which bsdtar) $(which tar)
- 
-#RUN tar -xzvf cellranger-3.1.0.tar.gz \
-#    && mv $(which tar)~ $(which tar) \
-#    && rm cellranger-3.1.0.tar.gz
-
-#ENV PATH="cellranger-3.1.0:${PATH}"
-
-#RUN wget http://cf.10xgenomics.com/supp/cell-exp/refdata-cellranger-GRCh38-3.0.0.tar.gz
-#RUN tar -xzvf refdata-cellranger-GRCh38-3.0.0.tar.gz
-
-# inflection point
-#RUN wget https://github.com/broadinstitute/Drop-seq/releases/download/v2.3.0/Drop-seq_tools-2.3.0.zip \
-#    && unzip Drop-seq_tools-2.3.0.zip \
-#    && rm Drop-seq_tools-2.3.0.zip \
-#    && cp -R /Drop-seq_tools-2.3.0/jar /usr/bin \
-#    && cp /Drop-seq_tools-2.3.0/BamTagHistogram /usr/bin
-
-#RUN Rscript -e "install.packages('BiocManager')" \
-#    && Rscript -e 'BiocManager::install("SingleCellExperiment")' \
-#    && Rscript -e 'BiocManager::install("SummarizedExperiment")' \
-#    && Rscript -e 'BiocManager::install("GenomicRanges")' \
-#    && Rscript -e 'BiocManager::install("IRanges")' \
-#    && Rscript -e 'BiocManager::install("S4Vectors")' \
-#    && Rscript -e 'BiocManager::install("GenomeInfoDb")' \
-#    && Rscript -e 'BiocManager::install("XVector")' 
-
-#    && Rscript -e 'BiocManager::install("DropletUtils")'
-
-#RUN Rscript -e "install.packages('devtools')" \
-#    && Rscript -e 'devtools::install_github("rajewsky-lab/dropbead")'
-
-#RUN Rscript -e "install.packages('Matrix')"
-
-
-#RUN Rscript -e "install.packages("/DropletUtils_1.4.2.tar.gz", repos = NULL, type="source")
-#RUN Rscript -e 'BiocManager::install("edgeR")' \ 
-#    && Rscript -e 'BiocManager::install("rhdf5")' \
-#    && Rscript -e 'BiocManager::install("HDF5Array")' \
-#    && Rscript -e 'BiocManager::install("dqrng")' \
-#    && Rscript -e 'BiocManager::install("beachmat")' \
-#    && Rscript -e 'BiocManager::install("Rhdf5lib")' 
-
-#RUN wget https://bioconductor.org/packages/release/bioc/src/contrib/DropletUtils_1.4.2.tar.gz 
-#RUN R CMD INSTALL DropletUtils_1.4.2.tar.gz
-RUN Rscript -e "install.packages('devtools')" 
-RUN Rscript -e 'devtools::install_github("LTLA/beachmat")'
-RUN Rscript -e 'devtools::install_github("MarioniLab/DropletUtils")'
-
-#RUN pip install umap-learn
+FROM bioconductor/release_base2:latest
 
 RUN apt-get update && \
-    apt-get install -y \
-            python3 \
-            python3-pip \
-            imagemagick 
+    apt-get install -y libcurl4-openssl-dev libhdf5-dev libssl-dev libxml2-dev \
+        imagemagick pdftk-java python3 python3-pip && \
+    rm /etc/ImageMagick-6/policy.xml
 
-RUN rm /etc/ImageMagick-6/policy.xml
+COPY install-base.R .
+RUN Rscript install-base.R
 
 RUN wget https://github.com/lmcinnes/umap/archive/0.4dev.zip \
     && unzip 0.4dev.zip \
@@ -94,14 +14,4 @@ RUN wget https://github.com/lmcinnes/umap/archive/0.4dev.zip \
     && cd umap-0.4dev \
     && pip3 install -r requirements.txt \
     && python3 setup.py install
-
-#RUN pip install toil[cwl]
-#RUN cp -r /usr/local/lib/python2.7/dist-packages/backports/ssl_match_hostname/ /usr/lib/python2.7/dist-packages/backports
-RUN apt-get update && \
-    apt-get install -y \
-            libxml2-dev 
-
-RUN Rscript -e "install.packages('devtools', dependencies=TRUE)" \
-    && Rscript -e 'devtools::install_github(repo = "hhoeflin/hdf5r")' \
-    && Rscript -e 'devtools::install_github(repo = "mojaveazure/loomR", ref = "develop")'
 

--- a/crescent/Dockerfile
+++ b/crescent/Dockerfile
@@ -1,4 +1,4 @@
-FROM r-base:latest
+FROM r-base:3.6.1
 
 RUN apt-get update && \
     apt-get install -y libcurl4-openssl-dev libhdf5-dev libssl-dev libxml2-dev \

--- a/crescent/install-base.R
+++ b/crescent/install-base.R
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
 
-install.packages(c('Seurat','fmsb','optparse','staplr','devtools'), dependencies=TRUE)
+install.packages(c('Bioconductor','Seurat','fmsb','optparse','staplr','devtools'), dependencies=TRUE)
 devtools::install_github(repo = 'hhoeflin/hdf5r')
 devtools::install_github(repo = 'mojaveazure/loomR', ref = 'develop')

--- a/crescent/install-base.R
+++ b/crescent/install-base.R
@@ -10,6 +10,6 @@ withCallingHandlers(
     warning = stop
 )
 withCallingHandlers(
-    devtools::install_github(c('hhoeflin/hdf5r', 'mojaveazure/loomR@develop'),
+    devtools::install_github(c('hhoeflin/hdf5r', 'mojaveazure/loomR@develop')),
     warning = stop
 )

--- a/crescent/install-base.R
+++ b/crescent/install-base.R
@@ -1,12 +1,12 @@
 #!/usr/bin/env Rscript
 
 withCallingHandlers(
-    install.packages('BiocManager'),
+    install.packages('BiocManager',repos='https://cloud.r-project.org/'),
     warning = stop
 )
 setRepositories(ind = 1:2)
 withCallingHandlers(
-    install.packages(c('fmsb','optparse','staplr','devtools')),
+    install.packages(c('fmsb','optparse','staplr','devtools'),repos='https://cloud.r-project.org/'),
     warning = stop
 )
 withCallingHandlers(

--- a/crescent/install-base.R
+++ b/crescent/install-base.R
@@ -1,6 +1,5 @@
 #!/usr/bin/env Rscript
 
-install.packages(c('Seurat','fmsb','optparse','staplr'))
-install.packages('devtools', dependencies=TRUE)
+install.packages(c('Seurat','fmsb','optparse','staplr','devtools'), dependencies=TRUE)
 devtools::install_github(repo = 'hhoeflin/hdf5r')
 devtools::install_github(repo = 'mojaveazure/loomR', ref = 'develop')

--- a/crescent/install-base.R
+++ b/crescent/install-base.R
@@ -6,7 +6,11 @@ withCallingHandlers(
 )
 setRepositories(ind = 1:2)
 withCallingHandlers(
-    install.packages(c('Seurat','fmsb','optparse','staplr','devtools')),
+    install.packages(c('fmsb','optparse','staplr','devtools')),
+    warning = stop
+)
+withCallingHandlers(
+    devtools::install_version('ggplot2', version = '3.1.1'),
     warning = stop
 )
 withCallingHandlers(

--- a/crescent/install-base.R
+++ b/crescent/install-base.R
@@ -1,0 +1,6 @@
+#!/usr/bin/env Rscript
+
+install.packages(c('Seurat','fmsb','optparse','staplr'))
+install.packages('devtools', dependencies=TRUE)
+devtools::install_github(repo = 'hhoeflin/hdf5r')
+devtools::install_github(repo = 'mojaveazure/loomR', ref = 'develop')

--- a/crescent/install-base.R
+++ b/crescent/install-base.R
@@ -10,7 +10,7 @@ withCallingHandlers(
     warning = stop
 )
 withCallingHandlers(
-    devtools::install_version('ggplot2', version = '3.1.1'),
+    devtools::install_version('Seurat', version = '3.1.1'),
     warning = stop
 )
 withCallingHandlers(

--- a/crescent/install-base.R
+++ b/crescent/install-base.R
@@ -1,5 +1,15 @@
 #!/usr/bin/env Rscript
 
-install.packages(c('Bioconductor','Seurat','fmsb','optparse','staplr','devtools'), dependencies=TRUE)
-devtools::install_github(repo = 'hhoeflin/hdf5r')
-devtools::install_github(repo = 'mojaveazure/loomR', ref = 'develop')
+withCallingHandlers(
+    install.packages('Bioconductor', dependencies=TRUE),
+    warning = stop
+)
+setRepositories(ind = 1:2)
+withCallingHandlers(
+    install.packages(c('Seurat','fmsb','optparse','staplr','devtools'), dependencies=TRUE),
+    warning = stop
+)
+withCallingHandlers(
+    devtools::install_github(c('hhoeflin/hdf5r', 'mojaveazure/loomR@develop'),
+    warning = stop
+)

--- a/crescent/install-base.R
+++ b/crescent/install-base.R
@@ -1,12 +1,12 @@
 #!/usr/bin/env Rscript
 
 withCallingHandlers(
-    install.packages('BiocManager', dependencies=TRUE),
+    install.packages('BiocManager'),
     warning = stop
 )
 setRepositories(ind = 1:2)
 withCallingHandlers(
-    install.packages(c('Seurat','fmsb','optparse','staplr','devtools'), dependencies=TRUE),
+    install.packages(c('Seurat','fmsb','optparse','staplr','devtools')),
     warning = stop
 )
 withCallingHandlers(

--- a/crescent/install-base.R
+++ b/crescent/install-base.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env Rscript
 
 withCallingHandlers(
-    install.packages('Bioconductor', dependencies=TRUE),
+    install.packages('BiocManager', dependencies=TRUE),
     warning = stop
 )
 setRepositories(ind = 1:2)

--- a/crescent/install-base.R
+++ b/crescent/install-base.R
@@ -10,7 +10,11 @@ withCallingHandlers(
     warning = stop
 )
 withCallingHandlers(
-    devtools::install_version('Seurat', version = '3.1.1'),
+    devtools::install_version("SDMTools", version = "1.1-221.2", repos = "http://cran.us.r-project.org"),
+    warning = stop
+)
+withCallingHandlers(
+    devtools::install_github("satijalab/seurat@v3.1.1"),
     warning = stop
 )
 withCallingHandlers(

--- a/crescent/seurat-v3.cwl
+++ b/crescent/seurat-v3.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 
 requirements:
   DockerRequirement:
-    dockerImageId: /usr/src/app/crescent-v3.simg
+    dockerImageId: /usr/src/app/crescent-seurat.simg
 
 baseCommand: [Rscript]
 


### PR DESCRIPTION
The image is available at `crescentdev/crescent-seurat` and clocks in at 0.1 GB smaller than `crescentdev/crescent-v3`. Tags are `latest` and `3.1.4-3.6.3-3.10` (Seurat-R-Bioconductor versions).

Commits should probably be squashed together.