### PR TITLE
pin setuptools to v57.5.0 as the newer versions deprecate use_2to3 wh…

### DIFF
--- a/wes/Dockerfile
+++ b/wes/Dockerfile
@@ -6,7 +6,7 @@ COPY mesos-wes.sh .
 COPY requirements.txt .
 COPY workflow-service workflow-service
 
-RUN python3.7 -m pip install -U pip && python3.7 -m pip install -U setuptools
+RUN python3.7 -m pip install -U pip && python3.7 -m pip install -U setuptools==57.5.0
 RUN python3.7 -m pip install -r requirements.txt
 
 WORKDIR /root/workflow-service

--- a/wes/requirements.txt
+++ b/wes/requirements.txt
@@ -1,8 +1,8 @@
-connexion
-docker
-minio
+connexion==2.3.0
+docker==2.5.1
+minio==7.1.0
 requests==2.23.0
-ruamel.yaml
-schema-salad
+ruamel.yaml==0.15.97
+schema-salad==4.5.20191229160203
 toil[cwl]==3.22.0
 werkzeug==0.16.1


### PR DESCRIPTION
…ich one of the dependencies (rdflib-jsonld v0.4.0) needs; specify Python package versions in requirements.txt to speed up Docker image build time